### PR TITLE
Changes for Zephyr 3.5 Update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,3 +3,4 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+    

--- a/config/boards/shields/woodpecker/Kconfig.defconfig
+++ b/config/boards/shields/woodpecker/Kconfig.defconfig
@@ -14,10 +14,7 @@ config I2C
 
 config SSD1306
     default y
-
-config SSD1306_REVERSE_MODE
-    default y
-
+    
 endif # ZMK_DISPLAY
 
 if LVGL
@@ -25,7 +22,7 @@ if LVGL
 config LV_Z_VDB_SIZE
     default 64
 
-config LV_Z_DPI
+config LV_DPI_DEF
     default 148
 
 config LV_Z_BITS_PER_PIXEL

--- a/config/boards/shields/woodpecker/woodpecker.keymap
+++ b/config/boards/shields/woodpecker/woodpecker.keymap
@@ -7,7 +7,8 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
-
+// required to toggle usb and bluetooth output
+#include <dt-bindings/zmk/outputs.h>
 
 // For QMK:
 // KC_NONUS_BSLASH (\|) is equivalent to ["é] key in Turkish keyboards.
@@ -157,7 +158,7 @@
         * |------+------+------+------+------+------| |------+------+------+------+------+------|
         * |      |      |      |      |      |      | |      |      |      |      |      |      |
         * |------+------+------+------+------+------| |------+------+------+------+------+------|
-        * |      |      |      |      |      |      | |      |      |      |      |      |      |
+        * |      |      |      |      |      |      | |      |      |      |OutUSB|OutBLE|OutTog|
         * |------+------+------+------+------+------| |------+------+------+------+------+------|
         * |CpsLck|      |      |      |      | BtClr| |      |      |      |      |      |      |
         * |------+------+------+------+------+------| |------+------+------+------+------+------|
@@ -168,7 +169,7 @@
             bindings = <
             &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4  &none             &bt BT_PRV  &bt BT_NXT  &none  &none  &none  &kp _LOCKSCREEN
             &none  &none  &none  &none  &none  &none                                            &none  &none  &none  &none  &none  &none
-            &none  &none  &none  &none  &none  &none                                            &none  &none  &none  &none  &none  &none
+            &none  &none  &none  &none  &none  &none                                            &none  &none  &none  &out OUT_USB  &out OUT_BLE  &out OUT_TOG
             &kp CLCK  &none  &none  &none  &none  &bt BT_CLR                                    &none  &none  &none  &none  &none  &none
             &none  &none  &none  &none  &sys_reset  &bootloader                                 &none  &none  &none  &none  &none  &tog _MAC
             >;
@@ -185,7 +186,7 @@
         * |------+------+------+------+------+------| |------+------+------+------+------+------|
         * |      |      |      |      |      |      | |      |      |      |      |      |      |
         * |------+------+------+------+------+------| |------+------+------+------+------+------|
-        * |      |Adj|<>|  ALT |  GUI |      |      | |      |      |      |      |      |      |
+        * |      |      |  ALT |  GUI |      |      | |      |      |      |      |      |      |
         * `-----------------------------------------' `-----------------------------------------'
         */
         mac_layer {
@@ -194,7 +195,7 @@
             &trans  &trans  &trans  &trans  &trans  &trans                                      &trans  &trans  &trans  &trans  &trans  &trans
             &trans  &trans  &trans  &trans  &trans  &trans                                      &trans  &trans  &trans  &trans  &trans  &trans
             &trans  &trans  &trans  &trans  &trans  &trans                                      &trans  &trans  &trans  &trans  &trans  &trans
-            &trans  &lt _ADJUST GRAVE   &kp LALT  &kp LGUI  &trans  &trans                      &trans  &trans  &trans  &trans  &trans  &trans
+            &trans  &trans  &kp LALT  &kp LGUI  &trans  &trans                                  &trans  &trans  &trans  &trans  &trans  &trans
             >;
         };
     };

--- a/config/boards/shields/woodpecker/woodpecker.overlay
+++ b/config/boards/shields/woodpecker/woodpecker.overlay
@@ -20,26 +20,26 @@
         diode-direction = "col2row";
 
         col-gpios
-            = <&gpio0 6  GPIO_ACTIVE_HIGH> // row0
-            , <&gpio0 8  GPIO_ACTIVE_HIGH> // row1
-            , <&gpio0 22 GPIO_ACTIVE_HIGH> // row2
-            , <&gpio0 24 GPIO_ACTIVE_HIGH> // row3
-            , <&gpio1 0  GPIO_ACTIVE_HIGH> // row4
-            , <&gpio1 4  GPIO_ACTIVE_HIGH> // row5
-            , <&gpio1 11 GPIO_ACTIVE_HIGH> // row6
-            , <&gpio1 13 GPIO_ACTIVE_HIGH> // row7
-            , <&gpio1 15 GPIO_ACTIVE_HIGH> // row8
-            , <&gpio0 2  GPIO_ACTIVE_HIGH> // row9
-            , <&gpio0 29 GPIO_ACTIVE_HIGH> // row10
-            , <&gpio0 31 GPIO_ACTIVE_HIGH> // row11
+            = <&gpio0 6  GPIO_ACTIVE_HIGH> // col0
+            , <&gpio0 8  GPIO_ACTIVE_HIGH> // col1
+            , <&gpio0 22 GPIO_ACTIVE_HIGH> // col2
+            , <&gpio0 24 GPIO_ACTIVE_HIGH> // col3
+            , <&gpio1 0  GPIO_ACTIVE_HIGH> // col4
+            , <&gpio1 4  GPIO_ACTIVE_HIGH> // col5
+            , <&gpio1 11 GPIO_ACTIVE_HIGH> // col6
+            , <&gpio1 13 GPIO_ACTIVE_HIGH> // col7
+            , <&gpio1 15 GPIO_ACTIVE_HIGH> // col8
+            , <&gpio0 2  GPIO_ACTIVE_HIGH> // col9
+            , <&gpio0 29 GPIO_ACTIVE_HIGH> // col10
+            , <&gpio0 31 GPIO_ACTIVE_HIGH> // col11
             ;
 
         row-gpios
-            = <&gpio0 11  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col0
-            , <&gpio1 6   (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col1
-            , <&gpio0 17  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col2
-            , <&gpio0 20  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col3
-            , <&gpio0 9   (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // col4
+            = <&gpio0 11  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row0
+            , <&gpio1 6   (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row1
+            , <&gpio0 17  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row2
+            , <&gpio0 20  (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row3
+            , <&gpio0 9   (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // row4
             ;
     };
 

--- a/config/boards/shields/woodpecker/woodpecker_oled.dtsi
+++ b/config/boards/shields/woodpecker/woodpecker_oled.dtsi
@@ -20,5 +20,6 @@
         com-invdir;
         com-sequential;
         prechargep = <0x22>;
+        inversion-on;
 	};
 };

--- a/config/woodpecker.keymap
+++ b/config/woodpecker.keymap
@@ -7,7 +7,8 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
-
+// required to toggle usb and bluetooth output
+#include <dt-bindings/zmk/outputs.h>
 
 // For QMK:
 // KC_NONUS_BSLASH (\|) is equivalent to ["é] key in Turkish keyboards.
@@ -157,7 +158,7 @@
         * |------+------+------+------+------+------| |------+------+------+------+------+------|
         * |      |      |      |      |      |      | |      |      |      |      |      |      |
         * |------+------+------+------+------+------| |------+------+------+------+------+------|
-        * |      |      |      |      |      |      | |      |      |      |      |      |      |
+        * |      |      |      |      |      |      | |      |      |      |OutUSB|OutBLE|OutTog|
         * |------+------+------+------+------+------| |------+------+------+------+------+------|
         * |CpsLck|      |      |      |      | BtClr| |      |      |      |      |      |      |
         * |------+------+------+------+------+------| |------+------+------+------+------+------|
@@ -168,7 +169,7 @@
             bindings = <
             &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4  &none             &bt BT_PRV  &bt BT_NXT  &none  &none  &none  &kp _LOCKSCREEN
             &none  &none  &none  &none  &none  &none                                            &none  &none  &none  &none  &none  &none
-            &none  &none  &none  &none  &none  &none                                            &none  &none  &none  &none  &none  &none
+            &none  &none  &none  &none  &none  &none                                            &none  &none  &none  &out OUT_USB  &out OUT_BLE  &out OUT_TOG
             &kp CLCK  &none  &none  &none  &none  &bt BT_CLR                                    &none  &none  &none  &none  &none  &none
             &none  &none  &none  &none  &sys_reset  &bootloader                                 &none  &none  &none  &none  &none  &tog _MAC
             >;
@@ -185,7 +186,7 @@
         * |------+------+------+------+------+------| |------+------+------+------+------+------|
         * |      |      |      |      |      |      | |      |      |      |      |      |      |
         * |------+------+------+------+------+------| |------+------+------+------+------+------|
-        * |      |Adj|<>|  ALT |  GUI |      |      | |      |      |      |      |      |      |
+        * |      |      |  ALT |  GUI |      |      | |      |      |      |      |      |      |
         * `-----------------------------------------' `-----------------------------------------'
         */
         mac_layer {
@@ -194,7 +195,7 @@
             &trans  &trans  &trans  &trans  &trans  &trans                                      &trans  &trans  &trans  &trans  &trans  &trans
             &trans  &trans  &trans  &trans  &trans  &trans                                      &trans  &trans  &trans  &trans  &trans  &trans
             &trans  &trans  &trans  &trans  &trans  &trans                                      &trans  &trans  &trans  &trans  &trans  &trans
-            &trans  &lt _ADJUST GRAVE   &kp LALT  &kp LGUI  &trans  &trans                      &trans  &trans  &trans  &trans  &trans  &trans
+            &trans  &trans  &kp LALT  &kp LGUI  &trans  &trans                                  &trans  &trans  &trans  &trans  &trans  &trans
             >;
         };
     };


### PR DESCRIPTION
- SSD1306_REVERSE_MODE  and LV_Z_DPI is deleted from [Kconfig.defconfig](https://github.com/Ardakilic/zmk-config-woodpecker/compare/main...ilkerulusoy:zmk-config-woodpecker:main?expand=1#diff-aae07a0a023f5ba3147f6cf6d57c8683f334e5e535b2c7ac3469c0ff6906aa06)
- inversion-on; is added to woodpecker_oled.dtsi


References : 
- https://zmk.dev/blog/2024/02/09/zephyr-3-5#ssd1306-oled-inverse-refactor